### PR TITLE
test: Use primary matcher names instead of alias functions

### DIFF
--- a/test/gchanges2notion.spec.ts
+++ b/test/gchanges2notion.spec.ts
@@ -98,15 +98,15 @@ describe('GrecentToNotion.send()', () => {
       },
       { items: [] }
     )
-    expect(mockSortedItems).toBeCalledWith('test-api-key', 'test-database-id')
-    expect(mockCreatePage).toBeCalledWith('test-api-key', 'test-1')
-    expect(mockUpdatePage).toBeCalledWith('test-api-key', 'test-2')
-    expect(mockUpdatePage).toBeCalledWith('test-api-key', 'test-3')
-    expect(mockUpdatePage).toBeCalledWith('test-api-key', {
+    expect(mockSortedItems).toHaveBeenCalledWith('test-api-key', 'test-database-id')
+    expect(mockCreatePage).toHaveBeenCalledWith('test-api-key', 'test-1')
+    expect(mockUpdatePage).toHaveBeenCalledWith('test-api-key', 'test-2')
+    expect(mockUpdatePage).toHaveBeenCalledWith('test-api-key', 'test-3')
+    expect(mockUpdatePage).toHaveBeenCalledWith('test-api-key', {
       page_id: 'test-over-1',
       archived: true
     })
-    expect(mockUpdatePage).toBeCalledWith('test-api-key', {
+    expect(mockUpdatePage).toHaveBeenCalledWith('test-api-key', {
       page_id: 'test-over-2',
       archived: true
     })

--- a/test/notion.spec.ts
+++ b/test/notion.spec.ts
@@ -28,7 +28,7 @@ describe('createPage()', () => {
       fetch: mockfetch
     } as any
     createPage('test-api-key', 'test-param' as any)
-    expect(mockfetch).toBeCalledWith('https://api.notion.com/v1/pages', {
+    expect(mockfetch).toHaveBeenCalledWith('https://api.notion.com/v1/pages', {
       method: 'post',
       headers: {
         Authorization: `Bearer test-api-key`,
@@ -53,7 +53,7 @@ describe('updatePage()', () => {
       page_id: 'test-page-id',
       properties: 'test-properties'
     } as any)
-    expect(mockfetch).toBeCalledWith(
+    expect(mockfetch).toHaveBeenCalledWith(
       'https://api.notion.com/v1/pages/test-page-id',
       {
         method: 'patch',
@@ -159,7 +159,7 @@ describe('getStoredItems()', () => {
       'test-page-id-1',
       'test-page-id-4'
     ])
-    expect(mockfetch).toBeCalledWith(
+    expect(mockfetch).toHaveBeenCalledWith(
       'https://api.notion.com/v1/databases/test-database-id/query',
       {
         method: 'post',
@@ -178,7 +178,7 @@ describe('getStoredItems()', () => {
         })
       }
     )
-    expect(mockfetch).toBeCalledWith(
+    expect(mockfetch).toHaveBeenCalledWith(
       'https://api.notion.com/v1/databases/test-database-id/query',
       {
         method: 'post',

--- a/test/params.spec.ts
+++ b/test/params.spec.ts
@@ -166,8 +166,8 @@ describe('genCreatePageParameters()', () => {
       params.push(param)
     }
 
-    expect(mockStoredItems.getPageId).toBeCalledWith('test-id-1')
-    expect(mockStoredItems.getPageId).toBeCalledWith('test-id-2')
+    expect(mockStoredItems.getPageId).toHaveBeenCalledWith('test-id-1')
+    expect(mockStoredItems.getPageId).toHaveBeenCalledWith('test-id-2')
 
     expect(params).toEqual([
       [

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -116,7 +116,7 @@ describe('asText()', () => {
     expect(asText('text/plain', 'text', fileObj as any, 'test-id')).toEqual(
       'test-plain-text'
     )
-    expect(mockGetAs).toBeCalledWith('text/plain')
+    expect(mockGetAs).toHaveBeenCalledWith('text/plain')
   })
 
   it('should get text from DcumentApp', () => {
@@ -136,7 +136,7 @@ describe('asText()', () => {
         'test-id'
       )
     ).toEqual('test-document-text')
-    expect(mockOpenById).toBeCalledWith('test-id')
+    expect(mockOpenById).toHaveBeenCalledWith('test-id')
   })
 
   it('should get text from SpreadsheetApp', () => {
@@ -181,9 +181,9 @@ test-val-3-1\ttest-val-3-2`)
       {} as any,
       'test-id'
     )
-    expect(mockOpenById).toBeCalledWith('test-id')
-    expect(mockRange).toBeCalledWith(1, 4, 3, 2)
-    expect(mockRange).toBeCalledWith(1, 4, 70, 70)
+    expect(mockOpenById).toHaveBeenCalledWith('test-id')
+    expect(mockRange).toHaveBeenCalledWith(1, 4, 3, 2)
+    expect(mockRange).toHaveBeenCalledWith(1, 4, 70, 70)
   })
 
   it('should get text from SlidesApp', () => {
@@ -235,7 +235,7 @@ test-shape1-2
 ---
 test-shape2-1
 test-shape2-2`)
-    expect(mockOpenById).toBeCalledWith('test-id')
+    expect(mockOpenById).toHaveBeenCalledWith('test-id')
   })
 })
 
@@ -290,8 +290,8 @@ describe('changedItems()', () => {
       items.push(item)
     }
 
-    expect(mockFileById).toBeCalledWith('test-id-1')
-    expect(mockFileById).toBeCalledWith('test-id-2')
+    expect(mockFileById).toHaveBeenCalledWith('test-id-1')
+    expect(mockFileById).toHaveBeenCalledWith('test-id-2')
     expect(items).toEqual([
       [
         {


### PR DESCRIPTION
https://jestjs.io/docs/upgrading-to-jest30
